### PR TITLE
Add SourceLink

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.2" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This lets users with the PDB file step into the library without first downloading the source files because the VS debugger does it on-the-fly.