### PR TITLE
Adopt Nerdbank.GitVersioning 

### DIFF
--- a/C5/C5.csproj
+++ b/C5/C5.csproj
@@ -4,7 +4,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>C5.snk</AssemblyOriginatorKeyFile>
-    <Version>3.0-beta</Version>
 
     <copyright>Copyright © Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm 2003-2016</copyright>
     <Company>Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm</Company>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="1.6.35" PrivateAssets="all" />
     <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.2" PrivateAssets="all" />
     <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.2" PrivateAssets="all" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.2" />
+  </ItemGroup>
+</Project>

--- a/version.json
+++ b/version.json
@@ -1,0 +1,12 @@
+{
+  "version": "3.0-beta",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$",
+    "^refs/heads/v\\d+\\.\\d+"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This automates assembly and package versioning such that you can publish updates to your package as frequently as you want without worrying about ensuring you have unique versions or having to touch the source code to update the version number. Only when you explicitly want to change the major.minor part of the version do you have to make a source change, and even then, it's only in one place instead of potentially several files.

See https://github.com/aarnott/nerdbank.gitversioning for a full description of this feature.

This includes the commit from #57 because both PRs have to add the `Directory.Build.props` file, so I would advise you consider and accept that PR before accepting this PR just to keep PR concerns isolated. If I were to isolate them here, you'd get a merge conflict for whichever PR you merge second.