### PR TITLE
Remove MSBuild.SDK.Extras from dependency list

### DIFF
--- a/C5/C5.csproj
+++ b/C5/C5.csproj
@@ -19,6 +19,6 @@
   </PropertyGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <ItemGroup>
-    <PackageReference Include="msbuild.sdk.extras" Version="1.0.3" />
+    <PackageReference Include="msbuild.sdk.extras" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
The built nupkg should not express this dependency as it is a build-time only dependency for this project.