### PR TITLE
Fix build on VS 2017 update 3

### DIFF
--- a/C5/C5.csproj
+++ b/C5/C5.csproj
@@ -19,6 +19,6 @@
   </PropertyGroup>
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   <ItemGroup>
-    <PackageReference Include="msbuild.sdk.extras" Version="1.0.3" />
+    <PackageReference Include="msbuild.sdk.extras" Version="1.0.5" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
When on a VS2017 Update 3 machine, packing this project fails. This PR fixes that so it works on both.