### PR TITLE
System.Collections.Generic `ISet<T>` and `IDictionary<T>` (Fixes #53)

### DIFF
--- a/C5.Tests/SupportClasses.cs
+++ b/C5.Tests/SupportClasses.cs
@@ -176,6 +176,8 @@ namespace C5.Tests
             throw exception;
         }
 
+        public override bool IsReadOnly => true;
+
         public override bool IsEmpty => false;
 
         public override int Count => contents.Length + 1;

--- a/C5.Tests/SupportClasses.cs
+++ b/C5.Tests/SupportClasses.cs
@@ -8,13 +8,22 @@ using SCG = System.Collections.Generic;
 
 namespace C5.Tests
 {
-    internal class SC : SCG.IComparer<string>
+    internal class SC : SCG.IComparer<string>, SCG.IEqualityComparer<string>
     {
         public int Compare(string a, string b)
         {
             return a.CompareTo(b);
         }
 
+        public bool Equals(string x, string y)
+        {
+            return StringComparer.Ordinal.Equals(x, y);
+        }
+
+        public int GetHashCode(string obj)
+        {
+            return StringComparer.Ordinal.GetHashCode(obj);
+        }
 
         public void appl(String s)
         {

--- a/C5.Tests/Templates/Set.cs
+++ b/C5.Tests/Templates/Set.cs
@@ -1,0 +1,330 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using SCG = System.Collections.Generic;
+
+namespace C5.Tests.Templates.Set
+{
+    [TestFixture]
+    public abstract class SCG_ISetBase
+    {
+        private SCG.ISet<string> set;
+
+        [SetUp]
+        public void Init()
+        {
+            set = CreateSet(new SC(), "A", "C", "E");
+        }
+
+        [TearDown]
+        public void Dispose()
+        {
+            set = null;
+        }
+
+        public abstract ISet<string> CreateSet(IEqualityComparer<string> equalityComparer, params string[] values);
+
+        [Test]
+        public void Add()
+        {
+            Assert.IsTrue(set.Add("Z"));
+            Assert.AreEqual(4, set.Count);
+            Assert.IsTrue(set.Contains("Z"));
+            Assert.IsFalse(set.Add("A"));
+        }
+
+        [Test]
+        public virtual void ExceptWith()
+        {
+            set.ExceptWith(new SCG.List<string> { "C", "E", "Z" });
+            Assert.AreEqual(1, set.Count);
+            Assert.IsTrue(set.Contains("A"));
+        }
+
+        [Test]
+        public virtual void ExceptWith_SameEqualityComparer()
+        {
+            set.ExceptWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "Z" });
+            Assert.AreEqual(1, set.Count);
+            Assert.IsTrue(set.Contains("A"));
+        }
+
+        [Test]
+        public virtual void IntersectWith()
+        {
+            set.IntersectWith(new SCG.List<string> { "C", "E", "Z" });
+            Assert.AreEqual(2, set.Count);
+            Assert.IsTrue(set.Contains("C"));
+            Assert.IsTrue(set.Contains("E"));
+        }
+
+        [Test]
+        public virtual void IntersectWith_SameEqualityComparer()
+        {
+            set.IntersectWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "Z" });
+            Assert.AreEqual(2, set.Count);
+            Assert.IsTrue(set.Contains("C"));
+            Assert.IsTrue(set.Contains("E"));
+        }
+
+        [Test]
+        public virtual void IsProperSubsetOf()
+        {
+            Assert.IsFalse(set.IsProperSubsetOf(new SCG.List<string>()));
+            Assert.IsFalse(set.IsProperSubsetOf(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsTrue(set.IsProperSubsetOf(new SCG.List<string> { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsProperSubsetOf(new SCG.List<string> { "C", "Z" }));
+            set.Clear();
+            Assert.IsTrue(set.IsProperSubsetOf(new SCG.List<string> { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsProperSubsetOf_SameEqualityComparer()
+        {
+            Assert.IsFalse(set.IsProperSubsetOf(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsFalse(set.IsProperSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsTrue(set.IsProperSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsProperSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "Z" }));
+            set.Clear();
+            Assert.IsTrue(set.IsProperSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsProperSupersetOf()
+        {
+            Assert.IsTrue(set.IsProperSupersetOf(new SCG.List<string>()));
+            Assert.IsFalse(set.IsProperSupersetOf(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsTrue(set.IsProperSupersetOf(new SCG.List<string> { "C", "A" }));
+            Assert.IsFalse(set.IsProperSupersetOf(new SCG.List<string> { "C", "Z" }));
+            set.Clear();
+            Assert.IsFalse(set.IsProperSupersetOf(new SCG.List<string> { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsProperSupersetOf_SameEqualityComparer()
+        {
+            Assert.IsTrue(set.IsProperSupersetOf(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsFalse(set.IsProperSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsTrue(set.IsProperSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+            Assert.IsFalse(set.IsProperSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "Z" }));
+            set.Clear();
+            Assert.IsFalse(set.IsProperSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsSubsetOf()
+        {
+            Assert.IsFalse(set.IsSubsetOf(new SCG.List<string>()));
+            Assert.IsTrue(set.IsSubsetOf(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsTrue(set.IsSubsetOf(new SCG.List<string> { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsSubsetOf(new SCG.List<string> { "C", "Z" }));
+            Assert.IsFalse(set.IsSubsetOf(new SCG.List<string> { "C", "A", "Z" }));
+            set.Clear();
+            Assert.IsTrue(set.IsSubsetOf(new SCG.List<string> { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsSubsetOf_SameEqualityComparer()
+        {
+            Assert.IsFalse(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsTrue(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsTrue(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "Z" }));
+            Assert.IsFalse(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A", "Z" }));
+            set.Clear();
+            Assert.IsTrue(set.IsSubsetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsSupersetOf()
+        {
+            Assert.IsTrue(set.IsSupersetOf(new SCG.List<string>()));
+            Assert.IsTrue(set.IsSupersetOf(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsFalse(set.IsSupersetOf(new SCG.List<string> { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsSupersetOf(new SCG.List<string> { "C", "Z" }));
+            Assert.IsTrue(set.IsSupersetOf(new SCG.List<string> { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.IsSupersetOf(new SCG.List<string> { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void IsSupersetOf_SameEqualityComparer()
+        {
+            Assert.IsTrue(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsTrue(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsFalse(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "Z" }));
+            Assert.IsTrue(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.IsSupersetOf(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void Overlaps()
+        {
+            Assert.IsFalse(set.Overlaps(new SCG.List<string>()));
+            Assert.IsTrue(set.Overlaps(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsTrue(set.Overlaps(new SCG.List<string> { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.Overlaps(new SCG.List<string> { "X", "Z" }));
+            Assert.IsTrue(set.Overlaps(new SCG.List<string> { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.Overlaps(new SCG.List<string> { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void Overlaps_SameEqualityComparer()
+        {
+            Assert.IsFalse(set.Overlaps(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsTrue(set.Overlaps(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsTrue(set.Overlaps(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.Overlaps(new TreeSet<string>(new SC(), new SC()) { "X", "Z" }));
+            Assert.IsTrue(set.Overlaps(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.Overlaps(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+        }
+
+        [Test]
+        public virtual void SetEquals()
+        {
+            Assert.IsFalse(set.SetEquals(new SCG.List<string>()));
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "C", "E", "A" }));
+            Assert.IsFalse(set.SetEquals(new SCG.List<string> { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.SetEquals(new SCG.List<string> { "X", "Z" }));
+            Assert.IsFalse(set.SetEquals(new SCG.List<string> { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.SetEquals(new SCG.List<string> { "C", "A" }));
+            Assert.IsTrue(set.SetEquals(new SCG.List<string>()));
+        }
+
+        [Test]
+        public virtual void SetEquals_SameEqualityComparer()
+        {
+            Assert.IsFalse(set.SetEquals(new TreeSet<string>(new SC(), new SC())));
+            Assert.IsTrue(set.SetEquals(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" }));
+            Assert.IsFalse(set.SetEquals(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A", "X" }));
+            Assert.IsFalse(set.SetEquals(new TreeSet<string>(new SC(), new SC()) { "X", "Z" }));
+            Assert.IsFalse(set.SetEquals(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+            set.Clear();
+            Assert.IsFalse(set.SetEquals(new TreeSet<string>(new SC(), new SC()) { "C", "A" }));
+            Assert.IsTrue(set.SetEquals(new TreeSet<string>(new SC(), new SC())));
+        }
+
+        [Test]
+        public virtual void SymmetricExceptWith()
+        {
+            set.SymmetricExceptWith(new SCG.List<string>());
+            Assert.AreEqual(3, set.Count);
+            set.SymmetricExceptWith(new SCG.List<string> { "C", "E", "R", "X" });
+            Assert.AreEqual(3, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "R", "X" }));
+            set.SymmetricExceptWith(new SCG.List<string> { "A", "R", "X" });
+            Assert.AreEqual(0, set.Count);
+
+            set.Clear();
+            set.SymmetricExceptWith(new SCG.List<string> { "C", "E", "A" });
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "C", "E", "A" }));
+        }
+
+        [Test]
+        public virtual void SymmetricExceptWith_SameEqualityComparer()
+        {
+            set.SymmetricExceptWith(new TreeSet<string>(new SC(), new SC()));
+            Assert.AreEqual(3, set.Count);
+            set.SymmetricExceptWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "R", "X" });
+            Assert.AreEqual(3, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "R", "X" }));
+            set.SymmetricExceptWith(new TreeSet<string>(new SC(), new SC()) { "A", "R", "X" });
+            Assert.AreEqual(0, set.Count);
+
+            set.Clear();
+            set.SymmetricExceptWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" });
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "C", "E", "A" }));
+        }
+
+        [Test]
+        public virtual void UnionWith()
+        {
+            set.UnionWith(new SCG.List<string>());
+            Assert.AreEqual(3, set.Count);
+            set.UnionWith(new SCG.List<string> { "C", "E", "R", "X" });
+            Assert.AreEqual(5, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "C", "E", "R", "X" }));
+            set.UnionWith(new SCG.List<string> { "A", "R", "X" });
+            Assert.AreEqual(5, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "C", "E", "R", "X" }));
+
+            set.Clear();
+            set.UnionWith(new SCG.List<string> { "C", "E", "A" });
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "C", "E", "A" }));
+        }
+
+        [Test]
+        public virtual void UnionWith_SameEqualityComparer()
+        {
+            set.UnionWith(new TreeSet<string>(new SC(), new SC()));
+            Assert.AreEqual(3, set.Count);
+            set.UnionWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "R", "X" });
+            Assert.AreEqual(5, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "C", "E", "R", "X" }));
+            set.UnionWith(new TreeSet<string>(new SC(), new SC()) { "A", "R", "X" });
+            Assert.AreEqual(5, set.Count);
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "A", "C", "E", "R", "X" }));
+
+            set.Clear();
+            set.UnionWith(new TreeSet<string>(new SC(), new SC()) { "C", "E", "A" });
+            Assert.IsTrue(set.SetEquals(new SCG.List<string> { "C", "E", "A" }));
+        }
+
+        // ICollection<T> members
+        [Test]
+        public virtual void Clear()
+        {
+            Assert.AreEqual(3, set.Count);
+            set.Clear();
+            Assert.AreEqual(0, set.Count);
+        }
+
+        [Test]
+        public virtual void Contains()
+        {
+            Assert.IsTrue(set.Contains("A"));
+            Assert.IsFalse(set.Contains("Z"));
+        }
+
+        [Test]
+        public virtual void CopyTo()
+        {
+            var values = new string[set.Count + 2];
+            set.CopyTo(values, 1);
+            Assert.AreEqual(null, values[0]);
+            Assert.AreEqual("A", values[1]);
+            Assert.AreEqual("C", values[2]);
+            Assert.AreEqual("E", values[3]);
+            Assert.AreEqual(null, values[4]);
+        }
+
+        [Test]
+        public virtual void Remove()
+        {
+            Assert.AreEqual(3, set.Count);
+            Assert.IsTrue(set.Remove("A"));
+            Assert.AreEqual(2, set.Count);
+            Assert.IsFalse(set.Remove("A"));
+            Assert.AreEqual(2, set.Count);
+        }
+
+        [Test]
+        public virtual void Count()
+        {
+            Assert.AreEqual(3, set.Count);
+            set.Add("Foo");
+            Assert.AreEqual(4, set.Count);
+        }
+
+        [Test]
+        public virtual void IsReadOnly()
+        {
+            Assert.AreEqual(false, set.IsReadOnly);
+        }
+    }
+}

--- a/C5.Tests/Trees/Dictionary.cs
+++ b/C5.Tests/Trees/Dictionary.cs
@@ -490,4 +490,264 @@ namespace C5.Tests.trees.RBDictionary
             }
         }
     }
+
+    [TestFixture]
+    public class SCGIDictionary
+    {
+        private SCG.IDictionary<string, string> dict;
+
+        [SetUp]
+        public void Init()
+        {
+            dict = new TreeDictionary<string, string>(new SC())
+            {
+                { "A", "1" },
+                { "C", "2" },
+                { "E", "3" }
+            };
+        }
+
+        [TearDown]
+        public void Dispose() { dict = null; }
+
+        [Test]
+        public void Add()
+        {
+            Assert.AreEqual(3, dict.Count);
+            dict.Add("S", "4");
+            Assert.AreEqual(4, dict.Count);
+        }
+
+        [Test]
+        public void ContainsKey()
+        {
+            Assert.IsTrue(dict.ContainsKey("A"));
+            Assert.IsFalse(dict.ContainsKey("Z"));
+        }
+
+        [Test]
+        public void Remove()
+        {
+            Assert.AreEqual(3, dict.Count);
+            Assert.IsTrue(dict.Remove("A"));
+            Assert.AreEqual(2, dict.Count);
+            Assert.IsFalse(dict.Remove("Z"));
+            Assert.AreEqual(2, dict.Count);
+        }
+
+        [Test]
+        public void TryGetValue()
+        {
+            Assert.IsTrue(dict.TryGetValue("C", out string value));
+            Assert.AreEqual("2", value);
+            Assert.IsFalse(dict.TryGetValue("Z", out value));
+            Assert.IsNull(value);
+        }
+
+        [Test]
+        public void GetItem()
+        {
+            Assert.AreEqual("3", dict["E"]);
+            Assert.Throws<NoSuchItemException>(() => { var x = dict["Z"]; });
+        }
+
+        [Test]
+        public void SetItem()
+        {
+            dict["C"] = "9";
+            Assert.AreEqual("9", dict["C"]);
+            dict["Z"] = "5";
+            Assert.AreEqual("5", dict["Z"]);
+        }
+
+        // ICollection<SCG.KeyValuePair<TKey, TValue>>
+        [Test]
+        public void Clear()
+        {
+            dict.Clear();
+            Assert.AreEqual(0, dict.Count);
+        }
+
+        [Test]
+        public void Contains()
+        {
+            Assert.IsTrue(dict.Contains(new SCG.KeyValuePair<string, string>("C", "2")));
+            Assert.IsFalse(dict.Contains(new SCG.KeyValuePair<string, string>("D", "2")));
+            Assert.IsFalse(dict.Contains(new SCG.KeyValuePair<string, string>("C", "6")));
+        }
+
+        [Test]
+        public void CopyTo()
+        {
+            var pairs = new SCG.KeyValuePair<string, string>[dict.Count];
+            dict.CopyTo(pairs, 0);
+            Assert.AreEqual("C", pairs[1].Key);
+            Assert.AreEqual("2", pairs[1].Value);
+            Assert.AreEqual("E", pairs[2].Key);
+            Assert.AreEqual("3", pairs[2].Value);
+        }
+
+        [Test]
+        public void RemovePair()
+        {
+            Assert.AreEqual(3, dict.Count);
+            Assert.IsTrue(dict.Remove(new SCG.KeyValuePair<string, string>("A", "1")));
+            Assert.AreEqual(2, dict.Count);
+            Assert.IsFalse(dict.Remove(new SCG.KeyValuePair<string, string>("Z", "9")));
+            Assert.AreEqual(2, dict.Count);
+        }
+
+        [Test]
+        public void Count()
+        {
+            Assert.AreEqual(3, dict.Count);
+        }
+
+        [Test]
+        public void IsReadOnly()
+        {
+            Assert.AreEqual(false, dict.IsReadOnly);
+        }
+
+        [Test]
+        public void GetEnumerable()
+        {
+            var enumerable = dict.GetEnumerator();
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual(new SCG.KeyValuePair<string, string>("A", "1"), enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual(new SCG.KeyValuePair<string, string>("C", "2"), enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual(new SCG.KeyValuePair<string, string>("E", "3"), enumerable.Current);
+            Assert.IsFalse(enumerable.MoveNext());
+        }
+
+        [Test]
+        public void Keys_GetEnumerable()
+        {
+            var enumerable = dict.Keys.GetEnumerator();
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("A", enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("C", enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("E", enumerable.Current);
+            Assert.IsFalse(enumerable.MoveNext());
+        }
+
+        [Test]
+        public void Keys_Count()
+        {
+            Assert.AreEqual(3, dict.Keys.Count);
+            dict.Remove("C");
+            Assert.AreEqual(2, dict.Keys.Count);
+        }
+
+        [Test]
+        public void Keys_IsReadOnly()
+        {
+            Assert.AreEqual(true, dict.Keys.IsReadOnly);
+        }
+
+        [Test]
+        public void Keys_Add()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Keys.Add("Foo"));
+        }
+
+        [Test]
+        public void Keys_Clear()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Keys.Clear());
+        }
+
+        [Test]
+        public void Keys_Contains()
+        {
+            Assert.IsTrue(dict.Keys.Contains("A"));
+            Assert.IsFalse(dict.Keys.Contains("B"));
+        }
+
+        [Test]
+        public void Keys_CopyTo()
+        {
+            var keys = new string[dict.Keys.Count + 2];
+            dict.Keys.CopyTo(keys, 1);
+            Assert.AreEqual(null, keys[0]);
+            Assert.AreEqual("A", keys[1]);
+            Assert.AreEqual("C", keys[2]);
+            Assert.AreEqual("E", keys[3]);
+            Assert.AreEqual(null, keys[4]);
+        }
+
+        [Test]
+        public void Keys_Remove()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Keys.Remove("Foo"));
+        }
+
+        [Test]
+        public void Values_GetEnumerable()
+        {
+            var enumerable = dict.Values.GetEnumerator();
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("1", enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("2", enumerable.Current);
+            Assert.IsTrue(enumerable.MoveNext());
+            Assert.AreEqual("3", enumerable.Current);
+            Assert.IsFalse(enumerable.MoveNext());
+        }
+
+        [Test]
+        public void Values_Count()
+        {
+            Assert.AreEqual(3, dict.Values.Count);
+            dict.Remove("C");
+            Assert.AreEqual(2, dict.Values.Count);
+        }
+
+        [Test]
+        public void Values_IsReadOnly()
+        {
+            Assert.AreEqual(true, dict.Values.IsReadOnly);
+        }
+
+        [Test]
+        public void Values_Add()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Values.Add("Foo"));
+        }
+
+        [Test]
+        public void Values_Clear()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Values.Clear());
+        }
+
+        [Test]
+        public void Values_Contains()
+        {
+            Assert.IsTrue(dict.Values.Contains("1"));
+            Assert.IsFalse(dict.Values.Contains("9"));
+        }
+
+        [Test]
+        public void Values_CopyTo()
+        {
+            var values = new string[dict.Values.Count + 2];
+            dict.Values.CopyTo(values, 1);
+            Assert.AreEqual(null, values[0]);
+            Assert.AreEqual("1", values[1]);
+            Assert.AreEqual("2", values[2]);
+            Assert.AreEqual("3", values[3]);
+            Assert.AreEqual(null, values[4]);
+        }
+
+        [Test]
+        public void Values_Remove()
+        {
+            Assert.Throws<ReadOnlyCollectionException>(() => dict.Values.Remove("1"));
+        }
+    }
 }

--- a/C5.Tests/Trees/RedBlackTreeSetTests.cs
+++ b/C5.Tests/Trees/RedBlackTreeSetTests.cs
@@ -1,8 +1,10 @@
 // This file is part of the C5 Generic Collection Library for C# and CLI
 // See https://github.com/sestoft/C5/blob/master/LICENSE.txt for licensing details.
 
+using C5.Tests.Templates.Set;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using SCG = System.Collections.Generic;
 
 namespace C5.Tests.trees.TreeSet
@@ -133,7 +135,7 @@ namespace C5.Tests.trees.TreeSet
         [Test]
         public void UpdateOrAdd2()
         {
-            ICollection<String> coll = new TreeSet<String>();
+            ICollection<string> coll = new TreeSet<String>();
             // s1 and s2 are distinct objects but contain the same text:
             String s1 = "abc", s2 = ("def" + s1).Substring(3);
             Assert.IsFalse(coll.UpdateOrAdd(s1, out string old));
@@ -3038,5 +3040,15 @@ namespace C5.Tests.trees.TreeSet
             }
         }
 
+    }
+
+    public class SCG_ISet : SCG_ISetBase
+    {
+        public override ISet<string> CreateSet(IEqualityComparer<string> equalityComparer, params string[] values)
+        {
+            var set = new TreeSet<string>(SCG.Comparer<string>.Default, equalityComparer);
+            set.UnionWith(values);
+            return set;
+        }
     }
 }

--- a/C5.UserGuideExamples/Graph.cs
+++ b/C5.UserGuideExamples/Graph.cs
@@ -573,6 +573,8 @@ namespace C5.UserGuideExamples
                 _graph = g;
             }
 
+            public override bool IsReadOnly => true;
+
             public override bool IsEmpty => _graph.EdgeCount == 0;
 
             public override int Count => _graph.EdgeCount;

--- a/C5.UserGuideExamples/MultiCollection.cs
+++ b/C5.UserGuideExamples/MultiCollection.cs
@@ -22,6 +22,8 @@ namespace C5.UserGuideExamples
             Count = c;
         }
 
+        public override bool IsReadOnly => true;
+
         public override int Count { get; }
 
         public override Speed CountSpeed => Speed.Constant;

--- a/C5/Arrays/ArrayList.cs
+++ b/C5/Arrays/ArrayList.cs
@@ -1481,7 +1481,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The value to check for.</param>
         /// <returns>True if the items is in this collection.</returns>
-        public virtual bool Contains(T item)
+        public override bool Contains(T item)
         { ValidityCheck(); return IndexOfInner(item) >= 0; }
 
 
@@ -1611,7 +1611,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The value to remove.</param>
         /// <returns>True if the item was found (and removed).</returns>
-        public virtual bool Remove(T item)
+        public override bool Remove(T item)
         {
             UpdateCheck();
 
@@ -2142,7 +2142,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>True</returns>
-        public virtual bool Add(T item)
+        public override bool Add(T item)
         {
             UpdateCheck();
 

--- a/C5/BaseClasses/ArrayBase.cs
+++ b/C5/BaseClasses/ArrayBase.cs
@@ -125,7 +125,7 @@ namespace C5
         /// <summary>
         /// Remove all items and reset size of internal array container.
         /// </summary>
-        public virtual void Clear()
+        public override void Clear()
         {
             UpdateCheck();
             array = new T[8];
@@ -238,6 +238,10 @@ namespace C5
             /// <value>True if this collection is empty.</value>
             public override bool IsEmpty { get { thebase.ModifyCheck(stamp); return count == 0; } }
 
+            /// <summary>
+            /// Gets a value indicating whether the <see cref="Range"/> is read-only. Always returns <c>true</c>.
+            /// </summary>
+            public override bool IsReadOnly => true;
 
             /// <summary>
             /// 

--- a/C5/BaseClasses/CollectionBase.cs
+++ b/C5/BaseClasses/CollectionBase.cs
@@ -287,7 +287,7 @@ namespace C5
         /// 
         /// </summary>
         /// <value>True if this collection is read only</value>
-        public virtual bool IsReadOnly => isReadOnlyBase;
+        public override bool IsReadOnly => isReadOnlyBase;
 
         #endregion
 

--- a/C5/BaseClasses/CollectionValueBase.cs
+++ b/C5/BaseClasses/CollectionValueBase.cs
@@ -653,5 +653,48 @@ namespace C5
         {
             return ToString(null, null);
         }
+
+        #region SCG.ICollection<T> Members
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="System.Collections.Generic.ICollection{T}"/> is read-only.
+        /// </summary>
+        public abstract bool IsReadOnly { get; }
+
+        /// <summary>
+        /// Adds an item to the <see cref="System.Collections.Generic.ICollection{T}"/>.
+        /// <para/>
+        /// The default implementation throws a <see cref="ReadOnlyCollectionException"/>. Override to provide an implementation.
+        /// </summary>
+        /// <param name="item">The object to add to the <see cref="System.Collections.Generic.ICollection{T}"/>.</param>
+        public virtual bool Add(T item) => throw new ReadOnlyCollectionException();
+
+        void System.Collections.Generic.ICollection<T>.Add(T item) => this.Add(item);
+
+        /// <summary>
+        /// Removes all items from the <see cref="System.Collections.Generic.ICollection{T}"/>.
+        /// <para/>
+        /// The default implementation throws a <see cref="ReadOnlyCollectionException"/>. Override to provide an implementation.
+        /// </summary>
+        public virtual void Clear() => throw new ReadOnlyCollectionException();
+
+        /// <summary>
+        /// Determines whether the <see cref="System.Collections.Generic.ICollection{T}"/> contains a specific value.
+        /// </summary>
+        /// <param name="item">The object to locate in the <see cref="System.Collections.Generic.ICollection{T}"/>.</param>
+        /// <returns><c>true</c> if item is found in the <see cref="System.Collections.Generic.ICollection{T}"/>; otherwise, <c>false</c>.</returns>
+        public virtual bool Contains(T item) => this.Exists((thisItem) => EqualityComparer<T>.Default.Equals(thisItem, item));
+
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the <see cref="System.Collections.Generic.ICollection{T}"/>.
+        /// <para/>
+        /// The default implementation throws a <see cref="ReadOnlyCollectionException"/>. Override to provide an implementation.
+        /// </summary>
+        /// <param name="item">The object to remove from the <see cref="System.Collections.Generic.ICollection{T}"/>.</param>
+        /// <returns><c>true</c> if item was successfully removed from the <see cref="System.Collections.Generic.ICollection{T}"/>; otherwise, <c>false</c>.
+        /// This method also returns <c>false</c> if item is not found in the original <see cref="System.Collections.Generic.ICollection{T}"/>.</returns>
+        public virtual bool Remove(T item) => throw new ReadOnlyCollectionException();
+
+        #endregion
     }
 }

--- a/C5/BaseClasses/DictionaryBase.cs
+++ b/C5/BaseClasses/DictionaryBase.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Collections.Generic;
+using SCG = System.Collections.Generic;
 
 namespace C5
 {
@@ -9,7 +9,7 @@ namespace C5
     /// 
     /// </summary>
     [Serializable]
-    public abstract class DictionaryBase<K, V> : CollectionValueBase<System.Collections.Generic.KeyValuePair<K, V>>, IDictionary<K, V>
+    public abstract class DictionaryBase<K, V> : CollectionValueBase<SCG.KeyValuePair<K, V>>, IDictionary<K, V>, SCG.IDictionary<K, V>
     {
         /// <summary>
         /// The set collection of entries underlying this dictionary implementation
@@ -186,7 +186,7 @@ namespace C5
         /// <summary>
         /// Remove all entries from the dictionary
         /// </summary>
-        public virtual void Clear() { pairs.Clear(); }
+        public override void Clear() { pairs.Clear(); }
 
         /// <summary>
         /// 
@@ -207,7 +207,7 @@ namespace C5
         }
 
         [Serializable]
-        private class LiftedEnumerable<H> : IEnumerable<System.Collections.Generic.KeyValuePair<K, V>> where H : K
+        private class LiftedEnumerable<H> : SCG.IEnumerable<SCG.KeyValuePair<K, V>> where H : K
         {
             private readonly System.Collections.Generic.IEnumerable<H> keys;
             public LiftedEnumerable(System.Collections.Generic.IEnumerable<H> keys) { this.keys = keys; }
@@ -379,6 +379,8 @@ namespace C5
             public override int Count => pairs.Count;
 
             public override Speed CountSpeed => Speed.Constant;
+
+            public override bool IsReadOnly => true;
         }
 
         [Serializable]
@@ -405,6 +407,8 @@ namespace C5
             public override int Count => pairs.Count;
 
             public override Speed CountSpeed => pairs.CountSpeed;
+
+            public override bool IsReadOnly => true;
         }
         #endregion
 
@@ -455,8 +459,8 @@ namespace C5
         /// <summary>
         /// 
         /// </summary>
-        /// <value>True if dictionary is read  only</value>
-        public virtual bool IsReadOnly => pairs.IsReadOnly;
+        /// <value>True if dictionary is read only</value>
+        public override bool IsReadOnly => pairs.IsReadOnly;
 
 
         /// <summary>
@@ -517,5 +521,83 @@ namespace C5
         {
             return Showing.ShowDictionary<K, V>(this, stringbuilder, ref rest, formatProvider);
         }
+
+        #region SCG.IDictionary<K, V> Members
+
+        SCG.ICollection<K> SCG.IDictionary<K, V>.Keys => this.Keys;
+
+        SCG.ICollection<V> SCG.IDictionary<K, V>.Values => this.Values;
+
+        int SCG.ICollection<SCG.KeyValuePair<K, V>>.Count => this.Count;
+
+        bool SCG.ICollection<SCG.KeyValuePair<K, V>>.IsReadOnly => this.IsReadOnly;
+
+        V SCG.IDictionary<K, V>.this[K key] { get => this[key]; set => this[key] = value; }
+
+        void SCG.IDictionary<K, V>.Add(K key, V value)
+        {
+            this.Add(key, value);
+        }
+
+        bool SCG.IDictionary<K, V>.ContainsKey(K key)
+        {
+            return this.Contains(key);
+        }
+
+        bool SCG.IDictionary<K, V>.Remove(K key)
+        {
+            return this.Remove(key);
+        }
+
+        bool SCG.IDictionary<K, V>.TryGetValue(K key, out V value)
+        {
+            SCG.KeyValuePair<K, V> p = new SCG.KeyValuePair<K, V>(key, default);
+
+            bool result = pairs.Find(ref p);
+            value = p.Value;
+            return result;
+        }
+
+        void SCG.ICollection<SCG.KeyValuePair<K, V>>.Add(SCG.KeyValuePair<K, V> item)
+        {
+            this.Add(item.Key, item.Value);
+        }
+
+        void SCG.ICollection<SCG.KeyValuePair<K, V>>.Clear()
+        {
+            this.Clear();
+        }
+
+        bool SCG.ICollection<SCG.KeyValuePair<K, V>>.Contains(SCG.KeyValuePair<K, V> item)
+        {
+            foreach (var thisItem in this)
+                if (thisItem.Equals(item))
+                    return true;
+
+            return false;
+        }
+
+        void SCG.ICollection<SCG.KeyValuePair<K, V>>.CopyTo(SCG.KeyValuePair<K, V>[] array, int arrayIndex)
+        {
+            if (arrayIndex < 0 || arrayIndex + Count > array.Length)
+                throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+
+            foreach (var item in this)
+                array[arrayIndex++] = new SCG.KeyValuePair<K, V>(item.Key, item.Value);
+        }
+
+        bool SCG.ICollection<SCG.KeyValuePair<K, V>>.Remove(SCG.KeyValuePair<K, V> item)
+        {
+            return this.Remove(item.Key);
+        }
+
+        SCG.IEnumerator<SCG.KeyValuePair<K, V>> SCG.IEnumerable<SCG.KeyValuePair<K, V>>.GetEnumerator()
+        {
+            foreach (var item in this)
+                yield return new SCG.KeyValuePair<K, V>(item.Key, item.Value);
+        }
+
+        #endregion
+
     }
 }

--- a/C5/Dictionaries/SortedDictionaryBase.cs
+++ b/C5/Dictionaries/SortedDictionaryBase.cs
@@ -424,7 +424,7 @@ namespace C5
             #region ICollection<K> Members
             public Speed ContainsSpeed => sorteddict.ContainsSpeed;
 
-            public bool Contains(K key) { return sorteddict.Contains(key); ; }
+            public override bool Contains(K key) { return sorteddict.Contains(key); }
 
             public int ContainsCount(K item) { return sorteddict.Contains(item) ? 1 : 0; }
 
@@ -479,7 +479,7 @@ namespace C5
 
             public bool UpdateOrAdd(K item, out K olditem) { throw new ReadOnlyCollectionException(); }
 
-            public bool Remove(K item) { throw new ReadOnlyCollectionException(); }
+            public override bool Remove(K item) { throw new ReadOnlyCollectionException(); }
 
             public bool Remove(K item, out K removeditem) { throw new ReadOnlyCollectionException(); }
 
@@ -487,7 +487,7 @@ namespace C5
 
             public void RemoveAll(SCG.IEnumerable<K> items) { throw new ReadOnlyCollectionException(); }
 
-            public void Clear() { throw new ReadOnlyCollectionException(); }
+            public override void Clear() { throw new ReadOnlyCollectionException(); }
 
             public void RetainAll(SCG.IEnumerable<K> items) { throw new ReadOnlyCollectionException(); }
 
@@ -500,7 +500,7 @@ namespace C5
 
             public bool DuplicatesByCounting => true;
 
-            public bool Add(K item) { throw new ReadOnlyCollectionException(); }
+            public override bool Add(K item) { throw new ReadOnlyCollectionException(); }
 
             void SCG.ICollection<K>.Add(K item) { throw new ReadOnlyCollectionException(); }
 

--- a/C5/Enumerators/MappedCollectionValue.cs
+++ b/C5/Enumerators/MappedCollectionValue.cs
@@ -22,6 +22,8 @@ namespace C5
 
         public override Speed CountSpeed => collectionValue.CountSpeed;
 
+        public override bool IsReadOnly => collectionValue.IsReadOnly;
+
         public override System.Collections.Generic.IEnumerator<V> GetEnumerator()
         {
             foreach (var item in collectionValue)

--- a/C5/Enumerators/MappedDirectedCollectionValue.cs
+++ b/C5/Enumerators/MappedDirectedCollectionValue.cs
@@ -26,6 +26,8 @@ namespace C5
 
         public override Speed CountSpeed => directedCollectionValue.CountSpeed;
 
+        public override bool IsReadOnly => directedCollectionValue.IsReadOnly;
+
         public override IDirectedCollectionValue<V> Backwards()
         {
             var ret = (MappedDirectedCollectionValue<T, V>)MemberwiseClone();

--- a/C5/Hashing/HashBag.cs
+++ b/C5/Hashing/HashBag.cs
@@ -81,7 +81,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to look for</param>
         /// <returns>True if bag contains item</returns>
-        public virtual bool Contains(T item)
+        public override bool Contains(T item)
         {
             return dict.Contains(new System.Collections.Generic.KeyValuePair<T, int>(item, 0));
         }
@@ -217,7 +217,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to remove</param>
         /// <returns>True if item was (found and) removed </returns>
-        public virtual bool Remove(T item)
+        public override bool Remove(T item)
         {
             var p = new SCG.KeyValuePair<T, int>(item, 0);
 
@@ -321,7 +321,7 @@ namespace C5
         /// <summary>
         /// Remove all items from the bag, resetting internal table to initial size.
         /// </summary>
-        public virtual void Clear()
+        public override void Clear()
         {
             UpdateCheck();
             if (size == 0)
@@ -569,7 +569,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>Always true</returns>
-        public virtual bool Add(T item)
+        public override bool Add(T item)
         {
             UpdateCheck();
             Add(ref item);

--- a/C5/Hashing/HashSet.cs
+++ b/C5/Hashing/HashSet.cs
@@ -451,7 +451,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to remove</param>
         /// <returns>True if item was (found and) removed </returns>
-        public virtual bool Remove(T item)
+        public override bool Remove(T item)
         {
             UpdateCheck();
             if (Remove(ref item))
@@ -515,7 +515,7 @@ namespace C5
         /// <summary>
         /// Remove all items from the set, resetting internal table to initial size.
         /// </summary>
-        public virtual void Clear()
+        public override void Clear()
         {
             UpdateCheck();
             int oldsize = size;
@@ -743,7 +743,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>True if item was added (i.e. not found)</returns>
-        public virtual bool Add(T item)
+        public override bool Add(T item)
         {
             UpdateCheck();
             return !SearchOrAdd(ref item, true, false, true);
@@ -753,10 +753,7 @@ namespace C5
         /// Add an item to this set.
         /// </summary>
         /// <param name="item">The item to add.</param>
-        void SCG.ICollection<T>.Add(T item)
-        {
-            Add(item);
-        }
+        void SCG.ICollection<T>.Add(T item) => Add(item);
 
         /// <summary>
         /// Add the elements from another collection with a more specialized item type 

--- a/C5/Heaps/IntervalHeap.cs
+++ b/C5/Heaps/IntervalHeap.cs
@@ -332,7 +332,7 @@ namespace C5
         /// <code>ReadOnlyCollectionException</code>
         /// </summary>
         /// <value>True if this collection is read-only.</value>
-        public bool IsReadOnly => false;
+        public override bool IsReadOnly => false;
 
         /// <summary>
         /// 

--- a/C5/Interfaces/ICollectionValue.cs
+++ b/C5/Interfaces/ICollectionValue.cs
@@ -10,8 +10,17 @@ namespace C5
     /// collection. The main usage for this interface is to be the return type of 
     /// query operations on generic collection.
     /// </summary>
-    public interface ICollectionValue<T> : IEnumerable<T>, IShowable
+    public interface ICollectionValue<T> : IEnumerable<T>, IShowable, System.Collections.Generic.ICollection<T>
     {
+        /// <summary>
+        /// Add an item to this collection if possible. If this collection has set
+        /// semantics, the item will be added if not already in the collection. If
+        /// bag semantics, the item will always be added.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        /// <returns>True if item was added.</returns>
+        new bool Add(T item);
+
         /// <summary>
         /// A flag bitmap of the events subscribable to by this collection.
         /// </summary>
@@ -63,7 +72,7 @@ namespace C5
         /// <summary>
         /// </summary>
         /// <value>The number of items in this collection</value>
-        int Count { get; }
+        new int Count { get; }
 
         /// <summary>
         /// The value is symbolic indicating the type of asymptotic complexity
@@ -79,7 +88,7 @@ namespace C5
         /// </summary>
         /// <param name="array">The array to copy to</param>
         /// <param name="index">The index at which to copy the first item</param>
-        void CopyTo(T[] array, int index);
+        new void CopyTo(T[] array, int index);
 
         /// <summary>
         /// Create an array with the items of this collection (in the same order as an

--- a/C5/Interfaces/IDictionary.cs
+++ b/C5/Interfaces/IDictionary.cs
@@ -27,7 +27,7 @@ namespace C5
         /// 
         /// </summary>
         /// <value>True if dictionary is read-only</value>
-        bool IsReadOnly { get; }
+        new bool IsReadOnly { get; }
 
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace C5
         /// <summary>
         /// Remove all entries from the dictionary
         /// </summary>
-        void Clear();
+        new void Clear();
 
 
         /// <summary>

--- a/C5/Interfaces/IExtensible.cs
+++ b/C5/Interfaces/IExtensible.cs
@@ -14,7 +14,7 @@ namespace C5
         /// <code>ReadOnlyCollectionException</code>
         /// </summary>
         /// <value>True if this collection is read-only.</value>
-        bool IsReadOnly { get; }
+        new bool IsReadOnly { get; }
 
         //TODO: wonder where the right position of this is
         /// <summary>
@@ -49,7 +49,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item to add.</param>
         /// <returns>True if item was added.</returns>
-        bool Add(T item);
+        new bool Add(T item);
 
         /// <summary>
         /// Add the elements from another collection with a more specialized item type 

--- a/C5/LinkedLists/HashedLinkedList.cs
+++ b/C5/LinkedLists/HashedLinkedList.cs
@@ -1119,6 +1119,8 @@ namespace C5
                 }
             }
 
+            public override bool IsReadOnly => true;
+
             public override bool IsEmpty { get { list.ModifyCheck(rangestamp); return count == 0; } }
 
             public override int Count { get { list.ModifyCheck(rangestamp); return count; } }

--- a/C5/LinkedLists/LinkedList.cs
+++ b/C5/LinkedLists/LinkedList.cs
@@ -776,6 +776,8 @@ namespace C5
                 }
             }
 
+            public override bool IsReadOnly => true;
+
             public override bool IsEmpty { get { list.ModifyCheck(rangestamp); return count == 0; } }
 
             public override int Count { get { list.ModifyCheck(rangestamp); return count; } }

--- a/C5/Trees/TreeBag.cs
+++ b/C5/Trees/TreeBag.cs
@@ -2310,6 +2310,7 @@ namespace C5
                 }
             }
 
+            public override bool IsReadOnly => treebag.IsReadOnly;
             public override bool IsEmpty => treebag.IsEmpty;
             public override int Count { get { int i = 0; foreach (System.Collections.Generic.KeyValuePair<T, int> p in this) { i++; } return i; } } //TODO: make better
             public override Speed CountSpeed => Speed.Linear;  //TODO: make better
@@ -2700,6 +2701,8 @@ namespace C5
                 this.start = start; length = count; this.forwards = forwards;
                 this.tree = tree; stamp = tree.stamp;
             }
+
+            public override bool IsReadOnly => true;
 
             public override bool IsEmpty => length == 0;
 
@@ -4288,6 +4291,7 @@ namespace C5
 
             IDirectedEnumerable<T> IDirectedEnumerable<T>.Backwards() { return Backwards(); }
 
+            public override bool IsReadOnly => true;
 
             public override bool IsEmpty => size == 0;
 

--- a/C5/Trees/TreeSet.cs
+++ b/C5/Trees/TreeSet.cs
@@ -2908,6 +2908,8 @@ namespace C5
                 this.tree = tree; stamp = tree.stamp;
             }
 
+            public override bool IsReadOnly => true;
+
             public override bool IsEmpty => length == 0;
 
             public override int Count => length;
@@ -4418,6 +4420,7 @@ namespace C5
 
             IDirectedEnumerable<T> IDirectedEnumerable<T>.Backwards() { return Backwards(); }
 
+            public override bool IsReadOnly => true;
 
             public override bool IsEmpty => size == 0;
 

--- a/C5/Trees/TreeSet.cs
+++ b/C5/Trees/TreeSet.cs
@@ -21,7 +21,7 @@ namespace C5
     /// leak possible with other usage modes.</i>
     /// </summary>
     [Serializable]
-    public class TreeSet<T> : SequencedBase<T>, IIndexedSorted<T>, IPersistentSorted<T>
+    public class TreeSet<T> : SequencedBase<T>, IIndexedSorted<T>, IPersistentSorted<T>, SCG.ISet<T>
     {
         #region Fields
 
@@ -518,6 +518,479 @@ namespace C5
             }
 
             #endregion
+        }
+
+        #endregion
+
+        #region ISet<T> Members
+
+        /// <summary>
+        /// Modifies the current <see cref="TreeSet{T}"/> object to contain all elements that are present in itself, the specified collection, or both.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current set.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual void UnionWith(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            AddAll(other);
+        }
+
+        /// <summary>
+        /// Modifies the current <see cref="TreeSet{T}"/> object so that it contains only elements that are also in a specified collection.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current set.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual void IntersectWith(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // intersection of anything with empty set is empty set, so return if count is 0
+            if (this.size == 0)
+            {
+                return;
+            }
+
+            // if other is empty, intersection is empty set; remove all elements and we're done
+            // can only figure this out if implements ICollection<T>. (IEnumerable<T> has no count)
+            if (other is SCG.ICollection<T> otherAsCollection)
+            {
+                if (otherAsCollection.Count == 0)
+                {
+                    Clear();
+                    return;
+                }
+
+                // faster if other is a hashset using same equality comparer; so check 
+                // that other is a hashset using the same equality comparer.
+                if (AreEqualityComparersEqual(this, otherAsCollection))
+                {
+                    IntersectWithHashSetWithSameEC(otherAsCollection);
+                    return;
+                }
+            }
+
+            IntersectWithEnumerable(other);
+        }
+
+        /// <summary>
+        /// Removes all elements in the specified collection from the current <see cref="TreeSet{T}"/> object.
+        /// </summary>
+        /// <param name="other">The collection of items to remove from the set.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual void ExceptWith(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // this is already the enpty set; return
+            if (this.size == 0)
+                return;
+
+            // special case if other is this; a set minus itself is the empty set
+            if (other == this)
+            {
+                Clear();
+                return;
+            }
+
+            // remove every element in other from this
+            foreach (T element in other)
+            {
+                Remove(element);
+            }
+        }
+
+        /// <summary>
+        /// Modifies the current set so that it contains only elements that are present either in the current 
+        /// <see cref="TreeSet{T}"/> object or in the specified collection, but not both.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual void SymmetricExceptWith(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // if set is empty, then symmetric difference is other
+            if (this.size == 0)
+            {
+                UnionWith(other);
+                return;
+            }
+
+            // special case this; the symmetric difference of a set with itself is the empty set
+            if (other == this)
+            {
+                Clear();
+                return;
+            }
+
+            // If other is a HashSet, it has unique elements according to its equality comparer,
+            // but if they're using different equality comparers, then assumption of uniqueness
+            // will fail. So first check if other is a hashset using the same equality comparer;
+            // symmetric except is a lot faster and avoids bit array allocations if we can assume
+            // uniqueness
+            if (other is SCG.ICollection<T> otherAsCollection && AreEqualityComparersEqual(this, otherAsCollection))
+            {
+                SymmetricExceptWithUniqueTreeSet(otherAsCollection);
+            }
+            else
+            {
+                var temp = new SCG.SortedSet<T>(other, comparer);
+                temp.ExceptWith(this);
+                ExceptWith(other);
+                UnionWith(temp);
+            }
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="TreeSet{T}"/> object is a subset of the specified collection.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <returns><c>true</c> if the <see cref="TreeSet{T}"/> object is a subset of other; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool IsSubsetOf(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            if (this.size == 0)
+            {
+                return true;
+            }
+
+            // faster if other has unique elements according to this equality comparer; so check 
+            // that other is a hashset using the same equality comparer.
+            if (other is SCG.ICollection<T> otherAsCollection && AreEqualityComparersEqual(this, otherAsCollection))
+            {
+                // if this has more elements then it can't be a subset
+                if (this.size > otherAsCollection.Count)
+                {
+                    return false;
+                }
+
+                // already checked that we're using same equality comparer. simply check that 
+                // each element in this is contained in other.
+                return IsSubsetOfTreeSetWithSameEC(otherAsCollection);
+            }
+
+            // we just need to return true if the other set
+            // contains all of the elements of the this set,
+            // but we need to use the comparison rules of the current set.
+            this.CheckUniqueAndUnfoundElements(other, false, out int uniqueCount, out int _);
+            return uniqueCount == this.size;
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="TreeSet{T}"/> object is a superset of the specified collection.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <returns><c>true</c> if the <see cref="TreeSet{T}"/> object is a superset of other; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool IsSupersetOf(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // try to fall out early based on counts
+            if (other is SCG.ICollection<T> otherAsCollection)
+            {
+                // if other is the empty set then this is a superset
+                if (otherAsCollection.Count == 0)
+                    return true;
+
+                // try to compare based on counts alone if other is a hashset with
+                // same equality comparer
+                if (AreEqualityComparersEqual(this, otherAsCollection))
+                {
+                    if (otherAsCollection.Count > this.size)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return this.ContainsAll(other);
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="TreeSet{T}"/> object is a proper superset of the specified collection.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <returns><c>true</c> if the <see cref="TreeSet{T}"/> object is a proper superset of other; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool IsProperSupersetOf(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // the empty set isn't a proper superset of any set.
+            if (this.size == 0)
+            {
+                return false;
+            }
+
+            if (other is SCG.ICollection<T> otherAsCollection)
+            {
+                // if other is the empty set then this is a superset
+                if (otherAsCollection.Count == 0)
+                    return true; // note that this has at least one element, based on above check
+
+                // faster if other is a hashset with the same equality comparer
+                if (AreEqualityComparersEqual(this, otherAsCollection))
+                {
+                    if (otherAsCollection.Count >= this.size)
+                    {
+                        return false;
+                    }
+                    // now perform element check
+                    return ContainsAll(otherAsCollection);
+                }
+            }
+
+            // couldn't fall out in the above cases; do it the long way
+            this.CheckUniqueAndUnfoundElements(other, true, out int uniqueCount, out int unfoundCount);
+            return uniqueCount < this.size && unfoundCount == 0;
+        }
+
+        /// <summary>
+        /// Determines whether a <see cref="TreeSet{T}"/> object is a proper subset of the specified collection.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <returns><c>true</c> if the <see cref="TreeSet{T}"/> object is a proper subset of other; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool IsProperSubsetOf(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+
+            if (other is SCG.ICollection<T> otherAsCollection)
+            {
+                // the empty set is a proper subset of anything but the empty set
+                if (this.size == 0)
+                    return otherAsCollection.Count > 0;
+
+                // faster if other is a hashset (and we're using same equality comparer)
+                if (AreEqualityComparersEqual(this, otherAsCollection))
+                {
+                    if (this.size >= otherAsCollection.Count)
+                    {
+                        return false;
+                    }
+                    // this has strictly less than number of items in other, so the following
+                    // check suffices for proper subset.
+                    return IsSubsetOfTreeSetWithSameEC(otherAsCollection);
+                }
+            }
+
+            this.CheckUniqueAndUnfoundElements(other, false, out int uniqueCount, out int unfoundCount);
+            return uniqueCount == this.size && unfoundCount > 0;
+        }
+
+        /// <summary>
+        /// Determines whether the current <see cref="TreeSet{T}"/> object and a specified collection share common elements.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/> object.</param>
+        /// <returns><c>true</c> if the <see cref="TreeSet{T}"/> object and other share at least one common element; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool Overlaps(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            if (this.size != 0)
+            {
+                foreach (var local in other)
+                {
+                    if (this.Contains(local))
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether the current <see cref="TreeSet{T}"/> and the specified collection contain the same elements.
+        /// </summary>
+        /// <param name="other">The collection to compare to the current <see cref="TreeSet{T}"/>.</param>
+        /// <returns><c>true</c> if the current <see cref="TreeSet{T}"/> is equal to other; otherwise, <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="other"/> is <c>null</c>.</exception>
+        public virtual bool SetEquals(SCG.IEnumerable<T> other)
+        {
+            if (other == null)
+                throw new ArgumentNullException(nameof(other));
+
+            // faster if other is a treeset and we're using same equality comparer
+            if (other is SCG.ICollection<T> otherAsCollection)
+            {
+                if (AreEqualityComparersEqual(this, otherAsCollection))
+                {
+                    // attempt to return early: since both contain unique elements, if they have 
+                    // different counts, then they can't be equal
+                    if (this.size != otherAsCollection.Count)
+                        return false;
+
+                    // already confirmed that the sets have the same number of distinct elements, so if
+                    // one is a superset of the other then they must be equal
+                    return ContainsAll(otherAsCollection);
+                }
+                else
+                {
+                    // if this count is 0 but other contains at least one element, they can't be equal
+                    if (this.size == 0 && otherAsCollection.Count > 0)
+                        return false;
+                }
+            }
+
+            this.CheckUniqueAndUnfoundElements(other, true, out int uniqueCount, out int unfoundCount);
+            return uniqueCount == this.size && unfoundCount == 0;
+        }
+
+        private void CheckUniqueAndUnfoundElements(SCG.IEnumerable<T> other, bool returnIfUnfound, out int uniqueCount, out int unfoundCount)
+        {
+            // need special case in case this has no elements.
+            if (this.size == 0)
+            {
+                int numElementsInOther = 0;
+                foreach (T item in other)
+                {
+                    numElementsInOther++;
+                    // break right away, all we want to know is whether other has 0 or 1 elements
+                    break;
+                }
+                uniqueCount = 0;
+                unfoundCount = numElementsInOther;
+                return;
+            }
+
+            int originalLastIndex = this.size;
+            var bitArray = new System.Collections.BitArray(originalLastIndex, false);
+
+            // count of unique items in other found in this
+            uniqueCount = 0;
+            // count of items in other not found in this
+            unfoundCount = 0;
+
+            foreach (var item in other)
+            {
+                var index = IndexOf(item);
+                if (index >= 0)
+                {
+                    if (!bitArray.Get(index))
+                    {
+                        // item hasn't been seen yet
+                        bitArray.Set(index, true);
+                        uniqueCount++;
+                    }
+                }
+                else
+                {
+                    unfoundCount++;
+                    if (returnIfUnfound)
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if equality comparers are equal. This is used for algorithms that can
+        /// speed up if it knows the other item has unique elements. I.e. if they're using 
+        /// different equality comparers, then uniqueness assumption between sets break.
+        /// </summary>
+        private static bool AreEqualityComparersEqual(TreeSet<T> set1, SCG.ICollection<T> set2)
+        {
+            if (set2 is TreeSet<T> treeSet)
+                return set1.EqualityComparer.Equals(treeSet.EqualityComparer);
+            else if (set2 is HashSet<T> hashSet)
+                return set1.EqualityComparer.Equals(hashSet.EqualityComparer);
+            else if (set2 is SCG.HashSet<T> scgHashSet)
+                return set1.EqualityComparer.Equals(scgHashSet.Comparer);
+            return false;
+        }
+
+        /// <summary>
+        /// If other is a hashset that uses same equality comparer, intersect is much faster 
+        /// because we can use other's Contains
+        /// </summary>
+        private void IntersectWithHashSetWithSameEC(SCG.ICollection<T> other)
+        {
+            foreach (var item in this)
+            {
+                if (!other.Contains(item))
+                {
+                    Remove(item);
+                }
+            }
+        }
+
+        private void IntersectWithEnumerable(SCG.IEnumerable<T> other)
+        {
+            // keep track of current last index; don't want to move past the end of our bit array
+            // (could happen if another thread is modifying the collection)
+            int originalLastIndex = this.size;
+            var bitArray = new System.Collections.BitArray(originalLastIndex, false);
+
+            foreach (var item in other)
+            {
+                int index = IndexOf(item);
+                if (index >= 0)
+                    bitArray.Set(index, true);
+            }
+
+            // if anything unmarked, remove it.
+            for (int i = originalLastIndex - 1; i >= 0; i--)
+            {
+                if (!bitArray.Get(i))
+                    RemoveAt(i);
+            }
+        }
+
+        /// <summary>
+        /// if other is a set, we can assume it doesn't have duplicate elements, so use this
+        /// technique: if can't remove, then it wasn't present in this set, so add.
+        /// 
+        /// As with other methods, callers take care of ensuring that other is a hashset using the
+        /// same equality comparer.
+        /// </summary>
+        private void SymmetricExceptWithUniqueTreeSet(SCG.ICollection<T> other)
+        {
+            foreach (T item in other)
+            {
+                if (!Remove(item))
+                {
+                    Add(item);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Implementation Notes:
+        /// If other is a hashset and is using same equality comparer, then checking subset is 
+        /// faster. Simply check that each element in this is in other.
+        /// 
+        /// Note: if other doesn't use same equality comparer, then Contains check is invalid,
+        /// which is why callers must take are of this.
+        /// 
+        /// If callers are concerned about whether this is a proper subset, they take care of that.
+        ///
+        /// </summary>
+        private bool IsSubsetOfTreeSetWithSameEC(SCG.ICollection<T> other)
+        {
+
+            foreach (T item in this)
+            {
+                if (!other.Contains(item))
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         #endregion

--- a/C5/WeakViewList.cs
+++ b/C5/WeakViewList.cs
@@ -58,7 +58,7 @@ namespace C5
             {
                 //V view = n.weakview.Target as V; //This provokes a bug in the beta1 verifyer
                 object o = n.weakview.Target;
-                V view = o is V ? (V)o : null;
+                V? view = o is V ? (V)o : null;
                 if (view == null)
                 {
                     Remove(n);

--- a/C5/Wrappers/GuardedCollection.cs
+++ b/C5/Wrappers/GuardedCollection.cs
@@ -37,7 +37,7 @@ namespace C5
         /// (This is a read-only wrapper)
         /// </summary>
         /// <value>True</value>
-        public virtual bool IsReadOnly => true;
+        public override bool IsReadOnly => true;
 
 
         /// <summary> </summary>
@@ -65,7 +65,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item</param>
         /// <returns>True if found</returns>
-        public virtual bool Contains(T item) { return collection.Contains(item); }
+        public override bool Contains(T item) => collection.Contains(item);
 
 
         /// <summary>
@@ -73,7 +73,7 @@ namespace C5
         /// </summary>
         /// <param name="item">The item</param>
         /// <returns>The number of copies</returns>
-        public virtual int ContainsCount(T item) { return collection.ContainsCount(item); }
+        public virtual int ContainsCount(T item) => collection.ContainsCount(item);
 
         /// <summary>
         /// 
@@ -153,7 +153,7 @@ namespace C5
         /// <exception cref="ReadOnlyCollectionException"> since this is a read-only wrapper</exception>
         /// <param name="item"></param>
         /// <returns></returns>
-        public virtual bool Remove(T item)
+        public override bool Remove(T item)
         { throw new ReadOnlyCollectionException("Collection cannot be modified through this guard object"); }
 
 
@@ -185,7 +185,7 @@ namespace C5
         /// <summary>
         /// </summary>
         /// <exception cref="ReadOnlyCollectionException"> since this is a read-only wrapper</exception>
-        public virtual void Clear()
+        public override void Clear()
         { throw new ReadOnlyCollectionException("Collection cannot be modified through this guard object"); }
 
 
@@ -235,7 +235,7 @@ namespace C5
         /// <exception cref="ReadOnlyCollectionException"> since this is a read-only wrapper</exception>
         /// <param name="item"></param>
         /// <returns></returns>
-        public virtual bool Add(T item)
+        public override bool Add(T item)
         { throw new ReadOnlyCollectionException(); }
 
         /// <summary>

--- a/C5/Wrappers/GuardedCollectionValue.cs
+++ b/C5/Wrappers/GuardedCollectionValue.cs
@@ -219,6 +219,43 @@ namespace C5
 
         #endregion
 
+        #region SCG.ICollection<T> Members
+
+        /// <summary>
+        /// Gets a value indicating whether the <see cref="System.Collections.Generic.ICollection{T}"/> is read-only.
+        /// </summary>
+        public virtual bool IsReadOnly => collectionvalue.IsReadOnly;
+
+        /// <summary>
+        /// Adds an item to the <see cref="ICollectionValue{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to add to the <see cref="ICollectionValue{T}"/>.</param>
+        public virtual bool Add(T item) => collectionvalue.Add(item);
+
+        void System.Collections.Generic.ICollection<T>.Add(T item) => this.Add(item);
+
+        /// <summary>
+        /// Removes all items from the <see cref="System.Collections.Generic.ICollection{T}"/>.
+        /// </summary>
+        public virtual void Clear() => collectionvalue.Clear();
+
+        /// <summary>
+        /// Determines whether the <see cref="System.Collections.Generic.ICollection{T}"/> contains a specific value.
+        /// </summary>
+        /// <param name="item">The object to locate in the <see cref="System.Collections.Generic.ICollection{T}"/>.</param>
+        /// <returns><c>true</c> if item is found in the <see cref="System.Collections.Generic.ICollection{T}"/>; otherwise, <c>false</c>.</returns>
+        public virtual bool Contains(T item) => collectionvalue.Contains(item);
+
+        /// <summary>
+        /// Removes the first occurrence of a specific object from the <see cref="System.Collections.Generic.ICollection{T}"/>.
+        /// </summary>
+        /// <param name="item">The object to remove from the <see cref="System.Collections.Generic.ICollection{T}"/>.</param>
+        /// <returns><c>true</c> if item was successfully removed from the <see cref="System.Collections.Generic.ICollection{T}"/>; otherwise, <c>false</c>.
+        /// This method also returns <c>false</c> if item is not found in the original <see cref="System.Collections.Generic.ICollection{T}"/>.</returns>
+        public virtual bool Remove(T item) => collectionvalue.Remove(item);
+
+        #endregion
+
         #region IShowable Members
 
         /// <summary>

--- a/C5/Wrappers/GuardedDictionary.cs
+++ b/C5/Wrappers/GuardedDictionary.cs
@@ -50,7 +50,7 @@ namespace C5
         /// (This is a read-only wrapper)
         /// </summary>
         /// <value>True</value>
-        public bool IsReadOnly => true;
+        public override bool IsReadOnly => true;
 
         /// <summary> </summary>
         /// <value>The collection of keys of the wrapped dictionary</value>
@@ -100,7 +100,7 @@ namespace C5
         /// <summary>
         /// </summary>
         /// <exception cref="ReadOnlyCollectionException"> since this is a read-only wrapper</exception>
-        public void Clear() => throw new ReadOnlyCollectionException();
+        public override void Clear() => throw new ReadOnlyCollectionException();
 
         /// <summary>
         /// 


### PR DESCRIPTION
This PR addresses #53:

* Implements `SCG.ISet<T>` on `TreeSet<T>`
* Implements `SCG.IDictionary<K, V>` on `DictionaryBase<K, V>`

I also attempted to implement `SCG.ISet<T>` on `HashSet<T>`, but since it seems to be missing a way to get and delete items by index, I am not sure how to proceed. Here is the (non compiling) attempt, in case you want to try to complete it:

* [4901d561dda3ee6385aa0f366ff34b51aee09904](https://github.com/NightOwl888/C5/commit/4901d561dda3ee6385aa0f366ff34b51aee09904)

## Redundant Behavior

Do note that the `AddAll`, `ContainsAll` `RetainAll`, and `RemoveAll` methods are now redundant with `UnionWith`, `IsSupersetOf`, `IntersectWith`, and `ExceptWith`, respectively.

### Options

1. Leave the redundant methods in place
2. Break C5 backward compatibility, but follow .NET conventions by removing (or making internal) `AddAll`, `ContainsAll` `RetainAll`, and `RemoveAll`
3. Preserve C5 backward compatibility, and hide `UnionWith`, `IsSupersetOf`, `IntersectWith`, and `ExceptWith` by using explicit interface declarations

## Performance

Most of the `ISet<T>` methods were reverse engineered from `SCG.HashSet<T>`, but it may be possible to implement some of the methods at a lower level for better performance - I didn't look into it.