### PR TITLE
chore: Update release notes and NuGet package

### DIFF
--- a/C5/C5.csproj
+++ b/C5/C5.csproj
@@ -4,27 +4,28 @@
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <Version>3.0.0</Version>
-    <Copyright>Copyright © Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm 2003-2021</Copyright>
+    <Copyright>Copyright © Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm 2003-2024</Copyright>
     <Company>Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm</Company>
     <Description>The C5 Generic Collection Library for C# and CLI is a comprehensive collection library supporting lists, sets, bags, dictionaries, priority queues, (FIFO) queues, and (LIFO) stacks. C5 runs on everything supporting .NET Standard 2.0: .NET Core 2.0+, .NET 4.6.1+, Mono, Xamarin, Universal Windows Platform, and Unity.</Description>
     <PackageTags>Generics Collections Heap TreeSet PriorityQueue</PackageTags>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageIcon>icon.png</PackageIcon>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://www.itu.dk/research/c5/</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
       <![CDATA[
         Release 3.0.0 of 2024-06-05
 
-          - C5 now targets .NET Standard 2.0, .NET 6.0 and .NET 8.0.
-          - Breaking change: `Rec<T1, T2, ...>` type removed as it was an exact copy of `ValueTuple<T1, T2, ...>`.
-          - Breaking change: All `public readonly` are now properties.
-          - Breaking change: `EventTypeEnum` is now `EventType`.
-          - Breaking change: custom `KeyValuePair<K, V>` has been replaced by the standard `System.Collections.Generic.KeyValue<TKey, TValue>` for better compatibility.
-          - Breaking change: `EnumerationDirection` is now `Direction`.
-          - `[Serializable]` attribute removed. Cf. [BinaryFormatter security guide](https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide).
+        - C5 now targets .NET Standard 2.0, .NET 6.0 and .NET 8.0.
+        - Breaking change: Rec<T1, T2, ...> type removed.
+        - Breaking change: All public readonly fields are now properties.
+        - Breaking change: EventTypeEnum is now EventType.
+        - Breaking change: custom KeyValuePair<K, V> has been replaced by the standard System.Collections.Generic.KeyValue<TKey, TValue> for better compatibility.
+        - Breaking change: EnumerationDirection is now Direction.
+        - Breaking change: Serializable attribute removed.
       ]]>
     </PackageReleaseNotes>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/sestoft/C5</RepositoryUrl>
@@ -34,6 +35,7 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="images\icon.png" Pack="true" PackagePath=""/>
+    <None Include="images\icon.png" Pack="true" PackagePath="\"/>
+    <None Include="..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 </Project>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2003-2021 Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm
+Copyright (c) 2003-2024 Niels Kokholm, Peter Sestoft, and Rasmus Lystrøm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -3,12 +3,12 @@
 ## Release 3.0.0 of 2024-06-05
 
 - C5 now targets .NET Standard 2.0, .NET 6.0 and .NET 8.0.
-- Breaking change: `Rec<T1, T2, ...>` type removed as it was an exact copy of `ValueTuple<T1, T2, ...>`.
-- Breaking change: All `public readonly` are now properties.
+- Breaking change: `Rec<T1, T2, ...>` type removed. Use `ValueTuple<T1, T2, ...>` instead.
+- Breaking change: All `public readonly` fields converted to properties.
 - Breaking change: `EventTypeEnum` is now `EventType`.
 - Breaking change: custom `KeyValuePair<K, V>` has been replaced by the standard `System.Collections.Generic.KeyValue<TKey, TValue>` for better compatibility.
 - Breaking change: `EnumerationDirection` is now `Direction`.
-- `[Serializable]` attribute removed. Cf. [BinaryFormatter security guide](https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide).
+- Breaking change: `[Serializable]` attribute removed. Cf. [BinaryFormatter security guide](https://docs.microsoft.com/en-us/dotnet/standard/serialization/binaryformatter-security-guide).
 
 ## Release 3.0.0-rc of 2021-12-22
 
@@ -78,9 +78,7 @@
 New functionality:
 
 - Interface `C5.ICollection<T>` now extends generic interface `System.Collections.Generic.ICollection<T>`. The `C5.ICollection<T>` interface in some cases describe different exceptions than specified by `SCG.ICollection<T>`, but we have not attempted to fix this because the .NET collection implemented in some cases throw other exceptions than those specified anyway.
-
 - Interface `C5.IList<T>` now extends interface non-generic interface `System.Collections.IList`, so C5 list collections can be passed to .NET GUI components and other framework methods.
-
 - Exception-free methods
 
   - `bool TryPredecessor(T x, out T res)`


### PR DESCRIPTION
This pull request primarily updates the `C5/C5.csproj` file, `LICENSE`, and `RELEASE-NOTES.md` files. The `C5/C5.csproj` file has been updated to include a new copyright year, include a `README.md` file in the package, and modify the release notes. The `LICENSE` file has been updated with a new copyright year. The `RELEASE-NOTES.md` file has been updated to modify the descriptions of breaking changes.

Updates to `C5/C5.csproj`:

* Updated the copyright year from 2021 to 2024.
* Added the `PackageLicenseExpression` and `PackageReadmeFile` tags.
* Modified the release notes to remove backticks and update the descriptions of breaking changes.
* Added a reference to the `README.md` file in the `ItemGroup` section.

Update to `LICENSE`:

* Updated the copyright year from 2021 to 2024.

Updates to `RELEASE-NOTES.md`:

* Modified the descriptions of breaking changes to remove backticks and update the descriptions.
* Removed extra line breaks.